### PR TITLE
Password reset support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ You'll first need to load the module and pass some configuration to the library.
         tenant: 'myb2ctenant.onmicrosoft.com',
         // the policy to use to sign in, can also be a sign up or sign in policy
         signInPolicy: 'mysigninpolicy',
+        // the policy to use for password reset
+        resetPolicy: 'mypasswordresetpolicy',
         // the the B2C application you want to authenticate with (that's just a random GUID - get yours from the portal)
         applicationId: '75ee2b43-ad2c-4366-9b8f-84b7d19d776e',
         // where MSAL will store state - localStorage or sessionStorage

--- a/lib/react-azure-adb2c.js
+++ b/lib/react-azure-adb2c.js
@@ -34,18 +34,36 @@ var state = {
   accessToken: null,
   scopes: []
 };
+var appConfig = {
+  instance: null,
+  tenant: null,
+  signInPolicy: null,
+  resetPolicy: null,
+  applicationId: null,
+  cacheLocation: null,
+  redirectUri: null,
+  postLogoutRedirectUri: null
+};
 
 function loggerCallback(logLevel, message, piiLoggingEnabled) {
   console.log(message);
 }
 
 function authCallback(errorDesc, token, error, tokenType) {
-  if (errorDesc) {
+  if (errorDesc && errorDesc.indexOf('AADB2C90118') > -1) {
+    redirect();
+  } else if (errorDesc) {
     console.log(error + ':' + errorDesc);
     state.stopLoopingRedirect = true;
   } else {
     acquireToken();
   }
+}
+
+function redirect() {
+  var localMsalApp = window.msal;
+  localMsalApp.authority = 'https://login.microsoftonline.com/tfp/' + appConfig.tenant + '/' + appConfig.resetPolicy;
+  acquireToken();
 }
 
 function acquireToken(successCallback) {
@@ -72,6 +90,7 @@ function acquireToken(successCallback) {
 
 var authentication = {
   initialize: function initialize(config) {
+    appConfig = config;
     var instance = config.instance ? config.instance : 'https://login.microsoftonline.com/tfp/';
     var authority = '' + instance + config.tenant + '/' + config.signInPolicy;
     var scopes = config.scopes;

--- a/src/react-azure-adb2c.js
+++ b/src/react-azure-adb2c.js
@@ -11,18 +11,37 @@ const state = {
   accessToken: null,
   scopes: []  
 }
+var appConfig = {
+  instance: null,
+  tenant: null,
+  signInPolicy: null,
+  resetPolicy: null,
+  applicationId: null,
+  cacheLocation: null,
+  redirectUri: null,
+  postLogoutRedirectUri: null
+};
 
 function loggerCallback(logLevel, message, piiLoggingEnabled) {
   console.log(message);
 }
 
 function authCallback(errorDesc, token, error, tokenType) {
-  if (errorDesc) {
+  if (errorDesc && errorDesc.indexOf('AADB2C90118') > -1) {
+    redirect();
+  }
+  else if (errorDesc) {
     console.log(error + ':' + errorDesc);
     state.stopLoopingRedirect = true;
   } else {
     acquireToken();
   }  
+}
+
+function redirect() {
+  const localMsalApp = window.msal;
+  localMsalApp.authority = `https://login.microsoftonline.com/tfp/${appConfig.tenant}/${appConfig.resetPolicy}`;
+  acquireToken();
 }
 
 function acquireToken(successCallback) {
@@ -46,10 +65,12 @@ function acquireToken(successCallback) {
       }
     });
   }
+  
 }
 
 const authentication = {
   initialize: (config) => {
+    appConfig = config;
     const instance = config.instance ? config.instance : 'https://login.microsoftonline.com/tfp/';
     const authority = `${instance}${config.tenant}/${config.signInPolicy}`;
     let scopes = config.scopes;


### PR DESCRIPTION
This pull request adds support for creating a password reset policy in an Azure B2C Tenant and handle the response back from the B2C SignupAndSignIn Policy and redirects to the specified password reset policy