### PR TITLE
Add validateAuthority as a property

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You'll first need to load the module and pass some configuration to the library.
     import authentication from 'react-azure-adb2c';
     authentication.initialize({
         // optional, will default to this
-        instance: 'https://login.microsoftonline.com/tfp/', 
+        instance: 'https://login.microsoftonline.com/tfp/',
         // your B2C tenant
         tenant: 'myb2ctenant.onmicrosoft.com',
         // the policy to use to sign in, can also be a sign up or sign in policy
@@ -42,15 +42,17 @@ You'll first need to load the module and pass some configuration to the library.
         redirectUri: 'http://localhost:3000',
         // optional, the URI to redirect to after logout
         postLogoutRedirectUri: 'http://myapp.com'
+        // optional, when ValidateAuthority is set to false, redirects are allowed to b2clogin.com.
+        validateAuthority: true
     });
-    
+
 ## Authenticating When The App Starts
 
 If you want to set things up so that a user is authenticated as soon as they hit your app (for example if you've got a link to an app from a landing page) then, in index.js, wrap the lines of code that launch the React app with the _authentication.run_ function:
 
     authentication.run(() => {
       ReactDOM.render(<App />, document.getElementById('root'));
-      registerServiceWorker();  
+      registerServiceWorker();
     });
 
 ## Triggering Authentication Based on Components Mounting (and routing)
@@ -62,7 +64,7 @@ If you want to set things up so that a user is authenticated as they visit a par
     import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
     import HomePage from './Homepage'
     import MembersArea from './MembersArea'
-    
+
     class App extends Component {
       render() {
         return (

--- a/lib/react-azure-adb2c.js
+++ b/lib/react-azure-adb2c.js
@@ -94,7 +94,7 @@ var authentication = {
     appConfig = config;
     var instance = config.instance ? config.instance : 'https://login.microsoftonline.com/tfp/';
     var authority = '' + instance + config.tenant + '/' + config.signInPolicy;
-    var validateAuthority = config.validateAuthority ? config.validateAuthority : true;
+    var validateAuthority = config.validateAuthority !== null || undefined ? config.validateAuthority : true;
     var scopes = config.scopes;
     if (!scopes || scopes.length === 0) {
       console.log('To obtain access tokens you must specify one or more scopes. See https://docs.microsoft.com/en-us/azure/active-directory-b2c/active-directory-b2c-access-tokens');

--- a/lib/react-azure-adb2c.js
+++ b/lib/react-azure-adb2c.js
@@ -43,7 +43,7 @@ var appConfig = {
   cacheLocation: null,
   redirectUri: null,
   postLogoutRedirectUri: null,
-  validateAuthority: false
+  validateAuthority: null
 };
 
 function loggerCallback(logLevel, message, piiLoggingEnabled) {
@@ -94,6 +94,7 @@ var authentication = {
     appConfig = config;
     var instance = config.instance ? config.instance : 'https://login.microsoftonline.com/tfp/';
     var authority = '' + instance + config.tenant + '/' + config.signInPolicy;
+    var validateAuthority = config.validateAuthority ? config.validateAuthority : true;
     var scopes = config.scopes;
     if (!scopes || scopes.length === 0) {
       console.log('To obtain access tokens you must specify one or more scopes. See https://docs.microsoft.com/en-us/azure/active-directory-b2c/active-directory-b2c-access-tokens');
@@ -105,7 +106,7 @@ var authentication = {
       cacheLocation: config.cacheLocation,
       postLogoutRedirectUri: config.postLogoutRedirectUri,
       redirectUri: config.redirectUri,
-      validateAuthority: config.validateAuthority
+      validateAuthority: validateAuthority
     });
   },
   run: function run(launchApp) {

--- a/lib/react-azure-adb2c.js
+++ b/lib/react-azure-adb2c.js
@@ -42,7 +42,8 @@ var appConfig = {
   applicationId: null,
   cacheLocation: null,
   redirectUri: null,
-  postLogoutRedirectUri: null
+  postLogoutRedirectUri: null,
+  validateAuthority: false
 };
 
 function loggerCallback(logLevel, message, piiLoggingEnabled) {
@@ -104,7 +105,7 @@ var authentication = {
       cacheLocation: config.cacheLocation,
       postLogoutRedirectUri: config.postLogoutRedirectUri,
       redirectUri: config.redirectUri,
-      validateAuthority: false
+      validateAuthority: config.validateAuthority
     });
   },
   run: function run(launchApp) {

--- a/lib/react-azure-adb2c.js
+++ b/lib/react-azure-adb2c.js
@@ -103,7 +103,9 @@ var authentication = {
     new Msal.UserAgentApplication(config.applicationId, authority, authCallback, { logger: logger,
       cacheLocation: config.cacheLocation,
       postLogoutRedirectUri: config.postLogoutRedirectUri,
-      redirectUri: config.redirectUri });
+      redirectUri: config.redirectUri,
+      validateAuthority: false
+    });
   },
   run: function run(launchApp) {
     state.launchApp = launchApp;

--- a/src/react-azure-adb2c.js
+++ b/src/react-azure-adb2c.js
@@ -19,7 +19,8 @@ var appConfig = {
   applicationId: null,
   cacheLocation: null,
   redirectUri: null,
-  postLogoutRedirectUri: null
+  postLogoutRedirectUri: null,
+  validateAuthority: false,
 };
 
 function loggerCallback(logLevel, message, piiLoggingEnabled) {
@@ -87,7 +88,7 @@ const authentication = {
         cacheLocation: config.cacheLocation,
         postLogoutRedirectUri: config.postLogoutRedirectUri,
         redirectUri: config.redirectUri,
-        validateAuthority: false,
+        validateAuthority: config.validateAuthority,
       }
     );
   },

--- a/src/react-azure-adb2c.js
+++ b/src/react-azure-adb2c.js
@@ -20,7 +20,7 @@ var appConfig = {
   cacheLocation: null,
   redirectUri: null,
   postLogoutRedirectUri: null,
-  validateAuthority: false,
+  validateAuthority: null,
 };
 
 function loggerCallback(logLevel, message, piiLoggingEnabled) {
@@ -74,6 +74,7 @@ const authentication = {
     appConfig = config;
     const instance = config.instance ? config.instance : 'https://login.microsoftonline.com/tfp/';
     const authority = `${instance}${config.tenant}/${config.signInPolicy}`;
+    const validateAuthority = config.validateAuthority ? config.validateAuthority : true
     let scopes = config.scopes;
     if (!scopes || scopes.length === 0) {
       console.log('To obtain access tokens you must specify one or more scopes. See https://docs.microsoft.com/en-us/azure/active-directory-b2c/active-directory-b2c-access-tokens');
@@ -88,7 +89,7 @@ const authentication = {
         cacheLocation: config.cacheLocation,
         postLogoutRedirectUri: config.postLogoutRedirectUri,
         redirectUri: config.redirectUri,
-        validateAuthority: config.validateAuthority,
+        validateAuthority: validateAuthority,
       }
     );
   },

--- a/src/react-azure-adb2c.js
+++ b/src/react-azure-adb2c.js
@@ -9,7 +9,7 @@ const state = {
   stopLoopingRedirect: false,
   launchApp: null,
   accessToken: null,
-  scopes: []  
+  scopes: []
 }
 var appConfig = {
   instance: null,
@@ -35,7 +35,7 @@ function authCallback(errorDesc, token, error, tokenType) {
     state.stopLoopingRedirect = true;
   } else {
     acquireToken();
-  }  
+  }
 }
 
 function redirect() {
@@ -45,7 +45,7 @@ function redirect() {
 }
 
 function acquireToken(successCallback) {
-  const localMsalApp = window.msal; 
+  const localMsalApp = window.msal;
   const user = localMsalApp.getUser(state.scopes);
   if (!user) {
     localMsalApp.loginRedirect(state.scopes);
@@ -65,7 +65,7 @@ function acquireToken(successCallback) {
       }
     });
   }
-  
+
 }
 
 const authentication = {
@@ -77,24 +77,26 @@ const authentication = {
     if (!scopes || scopes.length === 0) {
       console.log('To obtain access tokens you must specify one or more scopes. See https://docs.microsoft.com/en-us/azure/active-directory-b2c/active-directory-b2c-access-tokens');
       state.stopLoopingRedirect = true;
-    }  
+    }
     state.scopes = scopes;
-    
+
     new Msal.UserAgentApplication(config.applicationId,
       authority,
       authCallback,
       { logger: logger,
         cacheLocation: config.cacheLocation,
         postLogoutRedirectUri: config.postLogoutRedirectUri,
-        redirectUri: config.redirectUri }
+        redirectUri: config.redirectUri,
+        validateAuthority: false,
+      }
     );
   },
   run: (launchApp) => {
-    state.launchApp = launchApp; 
+    state.launchApp = launchApp;
     if (!window.msal.isCallback(window.location.hash) && window.parent === window && !window.opener) {
       if (!state.stopLoopingRedirect) {
         acquireToken();
-      }    
+      }
     }
   },
   required: (WrappedComponent, renderLoading) =>  {
@@ -112,7 +114,7 @@ const authentication = {
           this.setState({
             signedIn: true
           });
-        });        
+        });
       }
 
       render() {

--- a/src/react-azure-adb2c.js
+++ b/src/react-azure-adb2c.js
@@ -74,7 +74,7 @@ const authentication = {
     appConfig = config;
     const instance = config.instance ? config.instance : 'https://login.microsoftonline.com/tfp/';
     const authority = `${instance}${config.tenant}/${config.signInPolicy}`;
-    const validateAuthority = config.validateAuthority ? config.validateAuthority : true
+    const validateAuthority = (config.validateAuthority !== null || undefined) ? config.validateAuthority : true
     let scopes = config.scopes;
     if (!scopes || scopes.length === 0) {
       console.log('To obtain access tokens you must specify one or more scopes. See https://docs.microsoft.com/en-us/azure/active-directory-b2c/active-directory-b2c-access-tokens');


### PR DESCRIPTION
If you got a custom instance like 'https://your-tenant.b2clogin.com/ you need to set the validateAuthority property to false to allow redirect.

For more info:
https://docs.microsoft.com/en-us/azure/active-directory-b2c/b2clogin