### PR TITLE
Add support for b2clogin hostnames

### DIFF
--- a/src/react-azure-adb2c.js
+++ b/src/react-azure-adb2c.js
@@ -73,6 +73,7 @@ const authentication = {
     appConfig = config;
     const instance = config.instance ? config.instance : 'https://login.microsoftonline.com/tfp/';
     const authority = `${instance}${config.tenant}/${config.signInPolicy}`;
+    var validateAuthority = instance.indexOf('b2clogin.com') === -1;
     let scopes = config.scopes;
     if (!scopes || scopes.length === 0) {
       console.log('To obtain access tokens you must specify one or more scopes. See https://docs.microsoft.com/en-us/azure/active-directory-b2c/active-directory-b2c-access-tokens');
@@ -86,7 +87,8 @@ const authentication = {
       { logger: logger,
         cacheLocation: config.cacheLocation,
         postLogoutRedirectUri: config.postLogoutRedirectUri,
-        redirectUri: config.redirectUri }
+        redirectUri: config.redirectUri,
+        validateAuthority: validateAuthority }
     );
   },
   run: (launchApp) => {


### PR DESCRIPTION
MSFT Recommends to use b2clogin.com hostnames for B2C applications instead of login.microsoftonline.com. 

And given that MSAL.js is unable to validate b2clogin authority. This fix detects if the _instance_ points to b2clogin.com page and set the `validateAuthority` to false accordingly. 

Reference:
https://docs.microsoft.com/en-us/azure/active-directory-b2c/b2clogin
https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-b2c-overview